### PR TITLE
return array instead of object via json_decode

### DIFF
--- a/src/v1/Parser/Data.php
+++ b/src/v1/Parser/Data.php
@@ -30,7 +30,7 @@ class Data {
 				$input = file_get_contents('php://input');
 				
 				// first try json_decode, fallback to parse_str
-				if( ! $this->data = json_decode($input) ){
+				if( ! $this->data = json_decode($input, true) ){
 					parse_str($input, $this->data);
 				}
 		}


### PR DESCRIPTION
- data check immediately after expects an array, this can never happen without the second argument set to `true`
